### PR TITLE
Extract project-wide properties to Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>0.0.1</VersionPrefix>
+    <Authors>TheHuginn</Authors>
+  </PropertyGroup>
+</Project>

--- a/libtelebot.csproj
+++ b/libtelebot.csproj
@@ -5,9 +5,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageId>libtelebot</PackageId>
-    <Version>0.0.1</Version>
-    <Authors>TheHuginn</Authors>
     <RootNamespace>Telebot</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
- Better use VersionPrefix insted of Version, since that allow you to have base version + some suffix, which you add during CI phase.
- Authors usually global across repository, so better control that globally.
- If package is same as project name, no need to control it, it happens automatically. Unless you know that you will change filenames.