### PR TITLE
Dev

### DIFF
--- a/Models/Message.cs
+++ b/Models/Message.cs
@@ -79,6 +79,13 @@ namespace Telebot.Models;
 /// <c>entities</c> в Telegram Bot API; элементы массива описаны
 /// типом <see cref="MessageEntity"/>.
 /// </param>
+/// <param name="Poll">
+/// Опрос, содержащийся в сообщении. Заполняется только для сообщений,
+/// отправленных методом <c>sendPoll</c> (или пришедших в чат как опрос) —
+/// у обычных текстовых сообщений и медиа поле <c>null</c>. Через это поле
+/// доступен серверный <see cref="Models.Poll.Id"/>, необходимый для
+/// подписки на <c>poll</c>/<c>poll_answer</c>-апдейты.
+/// </param>
 public record Message(
     [property: JsonPropertyName("message_id")]
     int MessageId,
@@ -126,7 +133,10 @@ public record Message(
     string? Text,
 
     [property: JsonPropertyName("entities")]
-    MessageEntity[]? Entities
+    MessageEntity[]? Entities,
+
+    [property: JsonPropertyName("poll")]
+    Poll? Poll = null
 );
 
 /// <summary>

--- a/Models/Poll.cs
+++ b/Models/Poll.cs
@@ -1,0 +1,137 @@
+using System.Text.Json.Serialization;
+
+namespace Telebot.Models;
+
+/// <summary>
+/// Один вариант ответа в опросе
+/// (см. <see href="https://core.telegram.org/bots/api#polloption"/>).
+/// </summary>
+/// <param name="Text">
+/// Текст варианта ответа, 1–100 символов.
+/// </param>
+/// <param name="VoterCount">
+/// Количество пользователей, проголосовавших именно за этот вариант.
+/// В анонимных опросах — общее число голосов; в неанонимных — то же самое,
+/// но список голосовавших доступен отдельно через <c>poll_answer</c>-апдейты.
+/// </param>
+/// <param name="TextEntities">
+/// Специальные сущности в тексте варианта (форматирование, кастомные эмодзи и т. п.).
+/// Заполняется, только если в <see cref="Text"/> действительно есть такие сущности.
+/// </param>
+public record PollOption(
+    [property: JsonPropertyName("text")]
+    string Text,
+
+    [property: JsonPropertyName("voter_count")]
+    int VoterCount,
+
+    [property: JsonPropertyName("text_entities")]
+    MessageEntity[]? TextEntities = null
+);
+
+/// <summary>
+/// Опрос в чате
+/// (см. <see href="https://core.telegram.org/bots/api#poll"/>).
+/// </summary>
+/// <remarks>
+/// Одна и та же модель описывает и обычный опрос (<see cref="Type"/> = <c>"regular"</c>),
+/// и опрос-викторину (<see cref="Type"/> = <c>"quiz"</c>). Поля <see cref="CorrectOptionId"/>,
+/// <see cref="Explanation"/> и <see cref="ExplanationEntities"/> относятся только к
+/// викторинам и в обычных опросах будут <c>null</c>.
+/// <para/>
+/// <see cref="CorrectOptionId"/> возвращается **только** в двух случаях: боту-автору
+/// опроса и всем клиентам после того, как опрос закрыт (<see cref="IsClosed"/> = <c>true</c>).
+/// Пока идущая викторина «в глухую» для всех, кроме её автора-бота.
+/// </remarks>
+/// <param name="Id">
+/// Уникальный идентификатор опроса. Используется в <c>stopPoll</c> — впрочем,
+/// на стороне бота обычно проще держать пару <c>chat_id + message_id</c>, потому что
+/// именно они требуются для остановки.
+/// </param>
+/// <param name="Question">
+/// Текст вопроса, 1–300 символов.
+/// </param>
+/// <param name="Options">
+/// Список вариантов ответа (2–10 элементов).
+/// </param>
+/// <param name="TotalVoterCount">
+/// Общее число уникальных пользователей, проголосовавших в опросе.
+/// </param>
+/// <param name="IsClosed">
+/// <c>true</c>, если опрос уже закрыт и в него больше нельзя проголосовать.
+/// </param>
+/// <param name="IsAnonymous">
+/// <c>true</c>, если опрос анонимный. В анонимных опросах Telegram не присылает
+/// апдейты <c>poll_answer</c> с идентификатором проголосовавшего.
+/// </param>
+/// <param name="Type">
+/// Тип опроса: <c>"regular"</c> — обычный, <c>"quiz"</c> — викторина с правильным ответом.
+/// </param>
+/// <param name="AllowsMultipleAnswers">
+/// <c>true</c>, если пользователь может выбрать несколько вариантов сразу.
+/// Всегда <c>false</c> для викторин (<see cref="Type"/> = <c>"quiz"</c>).
+/// </param>
+/// <param name="QuestionEntities">
+/// Специальные сущности в тексте вопроса. Заполняется, только если они есть.
+/// </param>
+/// <param name="CorrectOptionId">
+/// Индекс правильного варианта (0-based) — только для викторин. Возвращается
+/// боту-автору всегда, а всем остальным клиентам — только после закрытия опроса.
+/// </param>
+/// <param name="Explanation">
+/// Текст пояснения, который показывается после ответа в викторине,
+/// 0–200 символов. Только для викторин.
+/// </param>
+/// <param name="ExplanationEntities">
+/// Специальные сущности в тексте <see cref="Explanation"/>.
+/// </param>
+/// <param name="OpenPeriod">
+/// Время в секундах, в течение которого опрос будет активен после отправки.
+/// </param>
+/// <param name="CloseDate">
+/// Абсолютное время автозакрытия опроса, Unix-timestamp.
+/// Взаимоисключающе с <see cref="OpenPeriod"/>.
+/// </param>
+public record Poll(
+    [property: JsonPropertyName("id")]
+    string Id,
+
+    [property: JsonPropertyName("question")]
+    string Question,
+
+    [property: JsonPropertyName("options")]
+    IReadOnlyList<PollOption> Options,
+
+    [property: JsonPropertyName("total_voter_count")]
+    int TotalVoterCount,
+
+    [property: JsonPropertyName("is_closed")]
+    bool IsClosed,
+
+    [property: JsonPropertyName("is_anonymous")]
+    bool IsAnonymous,
+
+    [property: JsonPropertyName("type")]
+    string Type,
+
+    [property: JsonPropertyName("allows_multiple_answers")]
+    bool AllowsMultipleAnswers,
+
+    [property: JsonPropertyName("question_entities")]
+    MessageEntity[]? QuestionEntities = null,
+
+    [property: JsonPropertyName("correct_option_id")]
+    int? CorrectOptionId = null,
+
+    [property: JsonPropertyName("explanation")]
+    string? Explanation = null,
+
+    [property: JsonPropertyName("explanation_entities")]
+    MessageEntity[]? ExplanationEntities = null,
+
+    [property: JsonPropertyName("open_period")]
+    int? OpenPeriod = null,
+
+    [property: JsonPropertyName("close_date")]
+    long? CloseDate = null
+);

--- a/Models/Poll.cs
+++ b/Models/Poll.cs
@@ -135,3 +135,49 @@ public record Poll(
     [property: JsonPropertyName("close_date")]
     long? CloseDate = null
 );
+
+/// <summary>
+/// Изменение голоса пользователя в неанонимном опросе
+/// (см. <see href="https://core.telegram.org/bots/api#pollanswer"/>).
+/// </summary>
+/// <remarks>
+/// Приходит в поле <see cref="Update.PollAnswer"/>. Присылается только для
+/// <b>неанонимных</b> опросов — в анонимных Telegram сознательно не раскрывает,
+/// кто и как проголосовал (см. <see cref="Poll.IsAnonymous"/>).
+/// <para/>
+/// Пустой массив <see cref="OptionIds"/> означает, что пользователь отозвал
+/// свой голос — это отдельное событие, не путать с «не голосовал».
+/// <para/>
+/// Голосующим может быть либо обычный пользователь (<see cref="User"/>), либо
+/// анонимный администратор канала / группы, голосующий от имени чата
+/// (<see cref="VoterChat"/>) — заполняется ровно одно из полей.
+/// </remarks>
+/// <param name="PollId">
+/// Идентификатор опроса, к которому относится голос — совпадает с <see cref="Poll.Id"/>
+/// того сообщения-опроса, за которым бот следит.
+/// </param>
+/// <param name="OptionIds">
+/// Индексы выбранных вариантов ответа (0-based) в порядке из <see cref="Poll.Options"/>.
+/// Пустой массив — пользователь отменил свой голос.
+/// </param>
+/// <param name="User">
+/// Пользователь, изменивший голос. Заполняется для неанонимного голосующего;
+/// <c>null</c>, если голос был отдан от имени чата (см. <see cref="VoterChat"/>).
+/// </param>
+/// <param name="VoterChat">
+/// Чат, от имени которого был изменён голос (анонимный админ канала / группы).
+/// <c>null</c>, если голосовал обычный пользователь.
+/// </param>
+public record PollAnswer(
+    [property: JsonPropertyName("poll_id")]
+    string PollId,
+
+    [property: JsonPropertyName("option_ids")]
+    IReadOnlyList<int> OptionIds,
+
+    [property: JsonPropertyName("user")]
+    User? User = null,
+
+    [property: JsonPropertyName("voter_chat")]
+    Chat? VoterChat = null
+);

--- a/Models/Update.cs
+++ b/Models/Update.cs
@@ -54,6 +54,11 @@ namespace Telebot.Models;
 /// Приходит только если бот явно подписан на <c>chat_member</c>
 /// через <c>allowed_updates</c> в <c>getUpdates</c>.
 /// </param>
+/// <param name="PollAnswer">
+/// Изменение голоса пользователя в неанонимном опросе. Для анонимных
+/// опросов Telegram этот апдейт не присылает вовсе — только счётчики
+/// в самом <see cref="Models.Poll"/> обновляются.
+/// </param>
 public record Update(
     [property: JsonPropertyName("update_id")]
     long UpdateId,
@@ -83,5 +88,8 @@ public record Update(
     ChatMemberUpdated? MyChatMember = null,
 
     [property: JsonPropertyName("chat_member")]
-    ChatMemberUpdated? ChatMember = null
+    ChatMemberUpdated? ChatMember = null,
+
+    [property: JsonPropertyName("poll_answer")]
+    PollAnswer? PollAnswer = null
 );

--- a/Requests/RequestParameters/StopPollRequestParams.cs
+++ b/Requests/RequestParameters/StopPollRequestParams.cs
@@ -1,0 +1,45 @@
+namespace Telebot;
+
+/// <summary>
+/// Параметры вызова метода <c>stopPoll</c> — принудительное закрытие опроса,
+/// ранее отправленного ботом. После вызова опрос переходит в состояние
+/// <see cref="Telebot.Models.Poll.IsClosed"/> = <c>true</c>, голосовать в нём больше нельзя,
+/// а всем клиентам становится виден правильный ответ (для викторин).
+/// </summary>
+/// <remarks>
+/// Bot API идентифицирует опрос **не** по <see cref="Telebot.Models.Poll.Id"/>, а по паре
+/// <see cref="ChatId"/> + <see cref="MessageId"/> сообщения, в котором он был отправлен.
+/// Именно поэтому этот метод возвращает уже закрытый <see cref="Telebot.Models.Poll"/>
+/// — со всей финальной статистикой голосов.
+/// <para/>
+/// Опущены <c>business_connection_id</c> (появится вместе с бизнес-сценариями в других
+/// запросах) и вариант с <c>inline_message_id</c> — инлайн-режим библиотека пока
+/// не поддерживает.
+/// </remarks>
+/// <param name="ChatId">Идентификатор чата, в котором находится опрос.</param>
+/// <param name="MessageId">Идентификатор сообщения с опросом.</param>
+/// <param name="ReplyMarkup">
+/// Новая инлайн-клавиатура под сообщением-опросом. Тип уже общего <see cref="IReplyMarkup"/>:
+/// Telegram здесь принимает только <see cref="Telebot.InlineKeyboardMarkup"/>. Если оставить
+/// <c>null</c> — существующая клавиатура снимется с сообщения.
+/// </param>
+public sealed record StopPollRequestParams(
+    long ChatId,
+    int MessageId,
+    InlineKeyboardMarkup? ReplyMarkup = null
+) : TelegramRequest("stopPoll")
+{
+    /// <summary>
+    /// Обязательные <c>chat_id</c> и <c>message_id</c> выдаются всегда;
+    /// <see cref="ReplyMarkup"/> уходит как JSON-строка — Telegram ожидает
+    /// именно такое представление составного объекта в form-запросе.
+    /// </summary>
+    public override IEnumerable<TelegramRequestField> GetRequestFields()
+    {
+        yield return new TelegramRequestField("chat_id", ChatId.ToString());
+        yield return new TelegramRequestField("message_id", MessageId.ToString());
+
+        if (ReplyMarkup is not null)
+            yield return new TelegramRequestField("reply_markup", ReplyMarkup.ToJson());
+    }
+}

--- a/Telegram.cs
+++ b/Telegram.cs
@@ -121,6 +121,14 @@ public interface ITelegramClient
     /// </summary>
     Task<Message> SendPollAsync(SendPollRequestParams requestParams,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Вызывает метод <c>stopPoll</c> — принудительно закрывает опрос,
+    /// ранее отправленный ботом, и возвращает уже закрытый <see cref="Poll"/>
+    /// со всей финальной статистикой голосов.
+    /// </summary>
+    Task<Poll> StopPollAsync(StopPollRequestParams requestParams,
+        CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -246,5 +254,12 @@ public sealed class Telegram : ITelegramClient
         CancellationToken cancellationToken)
     {
         return await _transport.RequestAsync<Message>(requestParams, _token, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<Poll> StopPollAsync(StopPollRequestParams requestParams,
+        CancellationToken cancellationToken)
+    {
+        return await _transport.RequestAsync<Poll>(requestParams, _token, cancellationToken);
     }
 }

--- a/libtelebot.csproj
+++ b/libtelebot.csproj
@@ -9,7 +9,7 @@
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Bucketlab.Telebot</PackageId>
-    <Version>0.0.72</Version>
+    <Version>0.0.73</Version>
     <Authors>TheHuginn</Authors>
     <Company>Bucketlab</Company>
     <Description>Библиотека клиент для телеграм</Description>

--- a/release_notes/0.0.73.md
+++ b/release_notes/0.0.73.md
@@ -1,0 +1,113 @@
+# 0.0.73 — `stopPoll` и модели `Poll` / `PollOption`
+
+До этого релиза бот умел **отправить** опрос через `sendPoll`, но не мог его закрыть — приходилось ждать, пока пользователь сам ответит или пока опрос протухнет по таймауту. 0.0.73 закрывает этот цикл: появляется `stopPoll` и рядом с ним — полноценные модели `Poll` / `PollOption`, в которые десериализуется финальная статистика.
+
+## Что добавилось
+
+### Модели `Poll` и `PollOption` (`Models/Poll.cs`)
+
+Ровно как в Bot API: `PollOption` — один вариант ответа (`text`, `voter_count`, опциональные `text_entities`); `Poll` — сам опрос со всеми полями, включая квиз-специфичные (`correct_option_id`, `explanation`, `explanation_entities`) и таймеры (`open_period`, `close_date`).
+
+Одна модель на оба типа опроса (`regular` / `quiz`) — квиз-поля просто `null` для обычного опроса. В XML-доках зафиксированы два нюанса:
+
+- `CorrectOptionId` возвращается **только** боту-автору опроса, а всем остальным клиентам — лишь после закрытия опроса;
+- `OpenPeriod` и `CloseDate` взаимоисключающи.
+
+### `StopPollRequestParams` (`Requests/RequestParameters/StopPollRequestParams.cs`)
+
+```csharp
+public sealed record StopPollRequestParams(
+    long ChatId,
+    int MessageId,
+    InlineKeyboardMarkup? ReplyMarkup = null
+) : TelegramRequest("stopPoll");
+```
+
+Опрос идентифицируется парой `chat_id + message_id`, а не `poll.id` — так же, как и в Bot API. Тип `ReplyMarkup` сужен до `InlineKeyboardMarkup?`, потому что Telegram здесь принимает только инлайн-клавиатуру. `null` снимает существующую клавиатуру.
+
+Опущены `business_connection_id` (появится вместе с бизнес-сценариями в других запросах) и вариант с `inline_message_id` — инлайн-режим библиотека пока не поддерживает.
+
+### `StopPollAsync` в `ITelegramClient` / `Telegram`
+
+Возвращает уже закрытый `Poll` с финальной статистикой голосов.
+
+### Поле `Message.Poll`
+
+В модель `Message` добавлено nullable-поле `Poll` — то самое, которое Telegram уже возвращает в ответе на `sendPoll` и приходит вместе с сообщениями-опросами через `getUpdates`. До 0.0.73 объект просто терялся при десериализации, теперь доступен напрямую:
+
+```csharp
+var sent = await bot.SendPollAsync(new SendPollRequestParams(...), ct);
+var pollId = sent.Poll!.Id; // серверный идентификатор — нужен, чтобы связать poll_answer-апдейты с исходным опросом
+```
+
+### Модель `PollAnswer` и поле `Update.PollAnswer`
+
+Появилась модель `PollAnswer` (`Models/Poll.cs`) и соответствующее поле в `Update`. Апдейт приходит на **каждое** изменение голоса пользователя в **неанонимном** опросе — в анонимных Telegram сознательно ничего не присылает (обновляются только счётчики внутри самого `Poll`).
+
+```csharp
+foreach (var update in updates)
+{
+    if (update.PollAnswer is not { } answer)
+        continue;
+
+    if (answer.OptionIds.Count == 0)
+        Console.WriteLine($"{answer.User?.Username} отозвал голос в опросе {answer.PollId}");
+    else
+        Console.WriteLine($"{answer.User?.Username} выбрал варианты {string.Join(", ", answer.OptionIds)}");
+}
+```
+
+Голосующим может быть либо обычный пользователь (`User`), либо анонимный админ канала / группы, голосующий от имени чата (`VoterChat`) — заполнено ровно одно из полей. Пустой `OptionIds` — это отдельное событие «пользователь отменил голос», не путать с «не голосовал».
+
+Чтобы `poll_answer` реально приходил через long-polling, его нужно явно включить в `allowed_updates` — по умолчанию Telegram его не шлёт.
+
+## Пример использования
+
+```csharp
+// Отправляем опрос
+var sent = await bot.SendPollAsync(
+    new SendPollRequestParams(
+        ChatId: chatId,
+        Question: "Ваш любимый язык?",
+        Options: new[]
+        {
+            new InputPollOption("C#"),
+            new InputPollOption("Go"),
+            new InputPollOption("Rust"),
+        }
+    ),
+    CancellationToken.None
+);
+
+// …через какое-то время закрываем его и получаем финальную статистику
+var closed = await bot.StopPollAsync(
+    new StopPollRequestParams(
+        ChatId: sent.Chat.Id,
+        MessageId: sent.MessageId
+    ),
+    CancellationToken.None
+);
+
+Console.WriteLine($"Всего голосов: {closed.TotalVoterCount}");
+foreach (var option in closed.Options)
+    Console.WriteLine($"  {option.Text}: {option.VoterCount}");
+```
+
+## Обновлённый список методов
+
+| Метод | Описание |
+|---|---|
+| `getMe` | информация о боте, проверка токена |
+| `getUpdates` | long-polling новых событий |
+| `setWebhook` | регистрация webhook-URL |
+| `sendMessage` | отправка текстовых сообщений |
+| `sendPhoto` | отправка фото (file_id / URL / поток) |
+| `editMessageText` | редактирование текста ранее отправленного сообщения |
+| `editMessageReplyMarkup` | замена или снятие инлайн-клавиатуры |
+| `sendPoll` | отправка опросов |
+| **`stopPoll`** | **новое:** принудительное закрытие опроса с возвратом финальной статистики |
+| `answerCallbackQuery` | подтверждение приёма нажатия кнопки |
+
+## Совместимость
+
+Ломающих изменений нет — только новые типы, один новый метод и два новых nullable-поля (`Message.Poll`, `Update.PollAnswer`).


### PR DESCRIPTION
# 0.0.73 — `stopPoll` и модели `Poll` / `PollOption`

До этого релиза бот умел **отправить** опрос через `sendPoll`, но не мог его закрыть — приходилось ждать, пока пользователь сам ответит или пока опрос протухнет по таймауту. 0.0.73 закрывает этот цикл: появляется `stopPoll` и рядом с ним — полноценные модели `Poll` / `PollOption`, в которые десериализуется финальная статистика.

## Что добавилось

### Модели `Poll` и `PollOption` (`Models/Poll.cs`)

Ровно как в Bot API: `PollOption` — один вариант ответа (`text`, `voter_count`, опциональные `text_entities`); `Poll` — сам опрос со всеми полями, включая квиз-специфичные (`correct_option_id`, `explanation`, `explanation_entities`) и таймеры (`open_period`, `close_date`).

Одна модель на оба типа опроса (`regular` / `quiz`) — квиз-поля просто `null` для обычного опроса. В XML-доках зафиксированы два нюанса:

- `CorrectOptionId` возвращается **только** боту-автору опроса, а всем остальным клиентам — лишь после закрытия опроса;
- `OpenPeriod` и `CloseDate` взаимоисключающи.

### `StopPollRequestParams` (`Requests/RequestParameters/StopPollRequestParams.cs`)

```csharp
public sealed record StopPollRequestParams(
    long ChatId,
    int MessageId,
    InlineKeyboardMarkup? ReplyMarkup = null
) : TelegramRequest("stopPoll");
```

Опрос идентифицируется парой `chat_id + message_id`, а не `poll.id` — так же, как и в Bot API. Тип `ReplyMarkup` сужен до `InlineKeyboardMarkup?`, потому что Telegram здесь принимает только инлайн-клавиатуру. `null` снимает существующую клавиатуру.

Опущены `business_connection_id` (появится вместе с бизнес-сценариями в других запросах) и вариант с `inline_message_id` — инлайн-режим библиотека пока не поддерживает.

### `StopPollAsync` в `ITelegramClient` / `Telegram`

Возвращает уже закрытый `Poll` с финальной статистикой голосов.

### Поле `Message.Poll`

В модель `Message` добавлено nullable-поле `Poll` — то самое, которое Telegram уже возвращает в ответе на `sendPoll` и приходит вместе с сообщениями-опросами через `getUpdates`. До 0.0.73 объект просто терялся при десериализации, теперь доступен напрямую:

```csharp
var sent = await bot.SendPollAsync(new SendPollRequestParams(...), ct);
var pollId = sent.Poll!.Id; // серверный идентификатор — нужен, чтобы связать poll_answer-апдейты с исходным опросом
```

### Модель `PollAnswer` и поле `Update.PollAnswer`

Появилась модель `PollAnswer` (`Models/Poll.cs`) и соответствующее поле в `Update`. Апдейт приходит на **каждое** изменение голоса пользователя в **неанонимном** опросе — в анонимных Telegram сознательно ничего не присылает (обновляются только счётчики внутри самого `Poll`).

```csharp
foreach (var update in updates)
{
    if (update.PollAnswer is not { } answer)
        continue;

    if (answer.OptionIds.Count == 0)
        Console.WriteLine($"{answer.User?.Username} отозвал голос в опросе {answer.PollId}");
    else
        Console.WriteLine($"{answer.User?.Username} выбрал варианты {string.Join(", ", answer.OptionIds)}");
}
```

Голосующим может быть либо обычный пользователь (`User`), либо анонимный админ канала / группы, голосующий от имени чата (`VoterChat`) — заполнено ровно одно из полей. Пустой `OptionIds` — это отдельное событие «пользователь отменил голос», не путать с «не голосовал».

Чтобы `poll_answer` реально приходил через long-polling, его нужно явно включить в `allowed_updates` — по умолчанию Telegram его не шлёт.

## Пример использования

```csharp
// Отправляем опрос
var sent = await bot.SendPollAsync(
    new SendPollRequestParams(
        ChatId: chatId,
        Question: "Ваш любимый язык?",
        Options: new[]
        {
            new InputPollOption("C#"),
            new InputPollOption("Go"),
            new InputPollOption("Rust"),
        }
    ),
    CancellationToken.None
);

// …через какое-то время закрываем его и получаем финальную статистику
var closed = await bot.StopPollAsync(
    new StopPollRequestParams(
        ChatId: sent.Chat.Id,
        MessageId: sent.MessageId
    ),
    CancellationToken.None
);

Console.WriteLine($"Всего голосов: {closed.TotalVoterCount}");
foreach (var option in closed.Options)
    Console.WriteLine($"  {option.Text}: {option.VoterCount}");
```

## Обновлённый список методов

| Метод | Описание |
|---|---|
| `getMe` | информация о боте, проверка токена |
| `getUpdates` | long-polling новых событий |
| `setWebhook` | регистрация webhook-URL |
| `sendMessage` | отправка текстовых сообщений |
| `sendPhoto` | отправка фото (file_id / URL / поток) |
| `editMessageText` | редактирование текста ранее отправленного сообщения |
| `editMessageReplyMarkup` | замена или снятие инлайн-клавиатуры |
| `sendPoll` | отправка опросов |
| **`stopPoll`** | **новое:** принудительное закрытие опроса с возвратом финальной статистики |
| `answerCallbackQuery` | подтверждение приёма нажатия кнопки |

## Совместимость

Ломающих изменений нет — только новые типы, один новый метод и два новых nullable-поля (`Message.Poll`, `Update.PollAnswer`).